### PR TITLE
Allow clicks when timer not running

### DIFF
--- a/appinfo.json
+++ b/appinfo.json
@@ -32,9 +32,9 @@
     },
     "sdkVersion": "2",
     "shortName": "WTFperMinute",
-    "uuid": "349be3a2-eff7-4b2c-ac59-20616c31c362",
+    "uuid": "7163a08b-76fa-489a-9b8a-12c597911369",
     "versionCode": 1,
-    "versionLabel": "0.9",
+    "versionLabel": "1.0",
     "watchapp": {
         "watchface": false
     }

--- a/appinfo.json
+++ b/appinfo.json
@@ -9,27 +9,28 @@
     "resources": {
         "media": [
             {
-                "file": "images/Pause.png",
-                "name": "ICON_PAUSE",
-                "type": "png"
-            },
-            {
                 "file": "images/Stop.png",
                 "name": "ICON_STOP",
-                "type": "png"
-            },
-            {
-                "file": "images/Cloud.png",
-                "name": "ICON_CLOUD",
                 "type": "png"
             },
             {
                 "file": "images/Play.png",
                 "name": "ICON_PLAY",
                 "type": "png"
+            },
+            {
+                "file": "images/Pause.png",
+                "name": "ICON_PAUSE",
+                "type": "png"
+            },
+            {
+                "file": "images/Cloud.png",
+                "name": "ICON_CLOUD",
+                "type": "png"
             }
         ]
     },
+    "sdkVersion": "2",
     "shortName": "WTFperMinute",
     "uuid": "349be3a2-eff7-4b2c-ac59-20616c31c362",
     "versionCode": 1,

--- a/src/wtfpm.c
+++ b/src/wtfpm.c
@@ -179,12 +179,10 @@ void handle_start_pause_click(ClickRecognizerRef recognizer, void *context) {
 }
 
 void handle_wtf_click(ClickRecognizerRef recognizer, void *context) {
-  if (state==RUNNING) {
-    static char counter[]="123456789";
-    wtf_count++;
-    snprintf(counter, sizeof(counter), "%d", wtf_count);
-    text_layer_set_text(s_wtf, counter);    
-  }
+  static char counter[]="123456789";
+  wtf_count++;
+  snprintf(counter, sizeof(counter), "%d", wtf_count);
+  text_layer_set_text(s_wtf, counter);    
 }
 
 void handle_ticks(struct tm *tick_time, TimeUnits units_changed) {

--- a/src/wtfpm.c
+++ b/src/wtfpm.c
@@ -146,7 +146,6 @@ void click_config_provider(void *context) {
 }
 
 void handle_reset_click(ClickRecognizerRef recognizer, void *context) {
-  if (state==PAUSED) {
     state = RESETTED;
     wtf_count=0;
     seconds=0;
@@ -155,7 +154,6 @@ void handle_reset_click(ClickRecognizerRef recognizer, void *context) {
     text_layer_set_text(s_wtf, "0");
     action_bar_layer_clear_icon(s_actionbarlayer, BUTTON_ID_DOWN);
     action_bar_layer_clear_icon(s_actionbarlayer, BUTTON_ID_SELECT);    
-  }
 }
 
 void handle_start_pause_click(ClickRecognizerRef recognizer, void *context) {

--- a/src/wtfpm.c
+++ b/src/wtfpm.c
@@ -14,6 +14,7 @@ void click_config_provider(void *context);
 void handle_reset_click(ClickRecognizerRef recognizer, void *context);
 void handle_start_pause_click(ClickRecognizerRef recognizer, void *context);
 void handle_wtf_click(ClickRecognizerRef recognizer, void *context);
+void handle_wtf_click_minus(ClickRecognizerRef recognizer, void *context);
 void handle_ticks(struct tm *tick_time, TimeUnits units_changed);
 void update_time(void);
 void update_wtfpm(void);
@@ -143,6 +144,7 @@ void click_config_provider(void *context) {
   window_single_click_subscribe(BUTTON_ID_UP, handle_start_pause_click);
   window_single_click_subscribe(BUTTON_ID_SELECT, handle_reset_click);
   window_single_click_subscribe(BUTTON_ID_DOWN, handle_wtf_click);
+  window_long_click_subscribe(BUTTON_ID_DOWN, 1000, handle_wtf_click_minus, NULL);
 }
 
 void handle_reset_click(ClickRecognizerRef recognizer, void *context) {
@@ -179,6 +181,13 @@ void handle_start_pause_click(ClickRecognizerRef recognizer, void *context) {
 void handle_wtf_click(ClickRecognizerRef recognizer, void *context) {
   static char counter[]="123456789";
   wtf_count++;
+  snprintf(counter, sizeof(counter), "%d", wtf_count);
+  text_layer_set_text(s_wtf, counter);    
+}
+
+void handle_wtf_click_minus(ClickRecognizerRef recognizer, void *context) {
+  static char counter[]="123456789";
+  wtf_count--;
   snprintf(counter, sizeof(counter), "%d", wtf_count);
   text_layer_set_text(s_wtf, counter);    
 }


### PR DESCRIPTION
Changed handle_wtf_click so it doesn't check if the timer is running. I need something like WTFperminute that has both a timer and counter, but they need to be independent of each other.

Also updated some things automatically via cloudpebble.
